### PR TITLE
Fixed permissions that were causing containers to crash

### DIFF
--- a/flagger/flagger-app.yaml
+++ b/flagger/flagger-app.yaml
@@ -48,6 +48,7 @@ spec:
       labels:
         app: detail
     spec:
+      serviceAccountName: flagger-envoy-proxies
       containers:
         - name: detail
           image: "public.ecr.aws/u2g6w7p2/eks-microservice-demo/detail:${APP_VERSION}"

--- a/flagger/flagger-app_noerror.yaml
+++ b/flagger/flagger-app_noerror.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: detail
     spec:
+      serviceAccountName: flagger-envoy-proxies
       containers:
         - name: detail
           image: "public.ecr.aws/u2g6w7p2/eks-microservice-demo/detail:${APP_VERSION_3}"

--- a/flagger/frontend.yaml
+++ b/flagger/frontend.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: frontend
     spec:
+      serviceAccountName: flagger-envoy-proxies
       containers:
         - name: frontend
           image: "public.ecr.aws/u2g6w7p2/eks-microservice-demo/frontend:${APP_VERSION}"


### PR DESCRIPTION
Modified frontend and app deployment yaml files to use flagger-envoy-proxies service account. Containers crash because they cannot call AppMesh APIs without it.